### PR TITLE
feat: add compact status bar display mode with icon/full/compact toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,6 @@ xcuserdata/
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 
+build/
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,xcode

--- a/Quality/Defaults.swift
+++ b/Quality/Defaults.swift
@@ -7,30 +7,51 @@
 
 import Foundation
 
+enum StatusBarDisplayMode: Int, CaseIterable {
+    case icon = 0
+    case text = 1
+    case compact = 2
+
+    var label: String {
+        switch self {
+        case .icon: return "Icon"
+        case .text: return "Full"
+        case .compact: return "Compact"
+        }
+    }
+}
+
 class Defaults: ObservableObject {
     static let shared = Defaults()
     private let kUserPreferIconStatusBarItem = "com.vincent-neo.LosslessSwitcher-Key-UserPreferIconStatusBarItem"
+    private let kStatusBarDisplayMode = "com.vincent-neo.LosslessSwitcher-Key-StatusBarDisplayMode"
     private let kSelectedDeviceUID = "com.vincent-neo.LosslessSwitcher-Key-SelectedDeviceUID"
     private let kUserPreferBitDepthDetection = "com.vincent-neo.LosslessSwitcher-Key-BitDepthDetection"
     private let kUserPreferDebugMenu = "com.vincent-neo.LosslessSwitcher-Key-DebugMenu"
     private let kShellScriptPath = "KeyShellScriptPath"
-    
+
     private init() {
         UserDefaults.standard.register(defaults: [
-            kUserPreferIconStatusBarItem : true,
             kUserPreferBitDepthDetection : false,
             kUserPreferDebugMenu : false
         ])
-        
-        userPreferIconStatusBarItem = UserDefaults.standard.bool(forKey: kUserPreferIconStatusBarItem)
-        
+
+        // Migrate from old boolean preference to new display mode enum
+        if let rawMode = UserDefaults.standard.object(forKey: kStatusBarDisplayMode) as? Int,
+           let mode = StatusBarDisplayMode(rawValue: rawMode) {
+            statusBarDisplayMode = mode
+        } else {
+            let oldPrefersIcon = UserDefaults.standard.object(forKey: kUserPreferIconStatusBarItem) as? Bool ?? true
+            statusBarDisplayMode = oldPrefersIcon ? .icon : .text
+        }
+
         self.userPreferBitDepthDetection = UserDefaults.standard.bool(forKey: kUserPreferBitDepthDetection)
         self.userPreferDebugMenu = UserDefaults.standard.bool(forKey: kUserPreferDebugMenu)
     }
-    
-    @Published var userPreferIconStatusBarItem: Bool {
+
+    @Published var statusBarDisplayMode: StatusBarDisplayMode {
         willSet {
-            UserDefaults.standard.set(newValue, forKey: kUserPreferIconStatusBarItem)
+            UserDefaults.standard.set(newValue.rawValue, forKey: kStatusBarDisplayMode)
         }
     }
     
@@ -64,8 +85,4 @@ class Defaults: ObservableObject {
         }
     }
     
-    var statusBarItemTitle: String {
-        let title = self.userPreferIconStatusBarItem ? "Show Sample Rate" : "Show Icon"
-        return title
-    }
 }

--- a/Quality/MenuView.swift
+++ b/Quality/MenuView.swift
@@ -19,10 +19,21 @@ struct MenuView: View {
             
             Divider()
             
-            Button {
-                defaults.userPreferIconStatusBarItem.toggle()
+            Menu {
+                ForEach(StatusBarDisplayMode.allCases, id: \.self) { mode in
+                    Button {
+                        defaults.statusBarDisplayMode = mode
+                    } label: {
+                        HStack {
+                            Text(mode.label)
+                            if defaults.statusBarDisplayMode == mode {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
             } label: {
-                Text(defaults.statusBarItemTitle)
+                Text("Display Mode")
             }
             
             Button {

--- a/Quality/QualityApp.swift
+++ b/Quality/QualityApp.swift
@@ -21,12 +21,15 @@ struct QualityApp: App {
                 .environmentObject(controller.outputDevices)
                 .environmentObject(defaults)
         } label: {
-            if defaults.userPreferIconStatusBarItem {
+            switch defaults.statusBarDisplayMode {
+            case .icon:
                 Image(systemName: "music.note")
                     .padding(.horizontal, 8)
-            }
-            else {
-                SampleRateLabel()
+            case .text:
+                SampleRateLabel(compact: false)
+                    .environmentObject(controller.outputDevices)
+            case .compact:
+                SampleRateLabel(compact: true)
                     .environmentObject(controller.outputDevices)
             }
         }

--- a/Quality/SampleRateLabel.swift
+++ b/Quality/SampleRateLabel.swift
@@ -10,11 +10,16 @@ import AppKit
 
 struct SampleRateLabel: View {
     @EnvironmentObject private var outputDevices: OutputDevices
+    var compact: Bool = false
 
     var body: some View {
         let parts = SampleRateText.parts(sampleRateKHz: outputDevices.currentSampleRate,
                                          bitDepth: outputDevices.currentBitDepth)
-        Image(nsImage: Self.renderStatusBarImage(rate: parts.rate, bit: parts.bit, isFlashing: outputDevices.isFlashing))
+        if compact {
+            Image(nsImage: Self.renderCompactStatusBarImage(rate: parts.rate, bit: parts.bit, isFlashing: outputDevices.isFlashing))
+        } else {
+            Image(nsImage: Self.renderStatusBarImage(rate: parts.rate, bit: parts.bit, isFlashing: outputDevices.isFlashing))
+        }
     }
 
     /// 将采样率文本渲染为 NSImage，文字底部对齐以匹配系统状态栏其他图标
@@ -54,6 +59,50 @@ struct SampleRateLabel: View {
 
         // 当不闪烁时，使用模板模式以适应黑白模式切换
         // 当闪烁时，关闭模板模式以显示真实颜色
+        image.isTemplate = !isFlashing
+        return image
+    }
+
+    /// 将采样率渲染为紧凑的两行 NSImage 用于状态栏显示
+    private static func renderCompactStatusBarImage(rate: String, bit: String?, isFlashing: Bool) -> NSImage {
+        let statusBarHeight: CGFloat = 22
+        let font = NSFont.systemFont(ofSize: 9, weight: .medium)
+        let textColor = isFlashing ? NSColor.systemGreen : NSColor.labelColor
+        let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: textColor]
+
+        let rateAttr = NSAttributedString(string: rate, attributes: attrs)
+        let rateSize = rateAttr.size()
+
+        // Strip "/ " prefix for compact display
+        let bitAttr: NSAttributedString?
+        let bitSize: NSSize
+        if let bit = bit {
+            let cleanBit = bit.hasPrefix("/ ") ? String(bit.dropFirst(2)) : bit
+            bitAttr = NSAttributedString(string: cleanBit, attributes: attrs)
+            bitSize = bitAttr!.size()
+        } else {
+            bitAttr = nil
+            bitSize = .zero
+        }
+
+        let maxWidth = ceil(max(rateSize.width, bitSize.width))
+
+        let image = NSImage(size: NSSize(width: maxWidth, height: statusBarHeight), flipped: false) { _ in
+            if let bitAttr = bitAttr {
+                let totalHeight = rateSize.height + bitSize.height
+                let startY = (statusBarHeight - totalHeight) / 2
+                // Bottom line: bit depth
+                bitAttr.draw(at: NSPoint(x: 0, y: startY))
+                // Top line: sample rate
+                rateAttr.draw(at: NSPoint(x: 0, y: startY + bitSize.height))
+            } else {
+                // Single line centered
+                let startY = (statusBarHeight - rateSize.height) / 2
+                rateAttr.draw(at: NSPoint(x: 0, y: startY))
+            }
+            return true
+        }
+
         image.isTemplate = !isFlashing
         return image
     }


### PR DESCRIPTION
Replace the old icon/text toggle with three display modes: Icon, Full, and Compact. Compact mode shows sample rate and bit depth as two small stacked lines to save menu bar space.

<img width="338" height="258" alt="image" src="https://github.com/user-attachments/assets/188fcd18-f767-44d5-9018-7f9fc6975f9e" />

