### PR TITLE
Add provider-based IINA and browser detection

### DIFF
--- a/LosslessSwitcherTests/AudioMetadataReaderTests.swift
+++ b/LosslessSwitcherTests/AudioMetadataReaderTests.swift
@@ -1,0 +1,101 @@
+//
+//  AudioMetadataReaderTests.swift
+//  LosslessSwitcherTests
+//
+//  Verifies AudioMetadataReader reads sample rates from generated WAV
+//  fixtures and returns nil for non-audio files.
+//
+
+import XCTest
+import AVFoundation
+@testable import LosslessSwitcher
+
+final class AudioMetadataReaderTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("AudioMetadataReaderTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func testReadsSampleRateFromGeneratedWavFixture() throws {
+        let wavURL = tempDir.appendingPathComponent("fixture-44100.wav")
+        try writeSilentWAV(to: wavURL, sampleRate: 44100, channels: 2, bitsPerChannel: 16)
+
+        let metadata = AudioMetadataReader.read(url: wavURL)
+        XCTAssertNotNil(metadata, "Expected non-nil metadata for a valid WAV fixture")
+        XCTAssertEqual(metadata?.sampleRate ?? 0, 44100, accuracy: 0.001,
+                       "Expected 44100 Hz sample rate")
+        XCTAssertNotNil(metadata?.bitDepth, "Expected non-nil bit depth for 16-bit WAV")
+        XCTAssertEqual(metadata?.bitDepth, 16)
+    }
+
+    func testReadsSampleRateFrom96kWavFixture() throws {
+        let wavURL = tempDir.appendingPathComponent("fixture-96000.wav")
+        try writeSilentWAV(to: wavURL, sampleRate: 96000, channels: 2, bitsPerChannel: 24)
+
+        let metadata = AudioMetadataReader.read(url: wavURL)
+        XCTAssertNotNil(metadata)
+        XCTAssertEqual(metadata?.sampleRate ?? 0, 96000, accuracy: 0.001)
+        XCTAssertEqual(metadata?.bitDepth, 24)
+    }
+
+    func testReturnsNilForUnsupportedTextFile() throws {
+        let textURL = tempDir.appendingPathComponent("not-audio.txt")
+        try "this is not audio".write(to: textURL, atomically: true, encoding: .utf8)
+
+        let metadata = AudioMetadataReader.read(url: textURL)
+        XCTAssertNil(metadata, "Expected nil for a plain text file")
+    }
+
+    func testReturnsNilForMissingFile() {
+        let missingURL = tempDir.appendingPathComponent("does-not-exist.wav")
+        let metadata = AudioMetadataReader.read(url: missingURL)
+        XCTAssertNil(metadata, "Expected nil for a non-existent file")
+    }
+
+    func testReturnsNilForDirectory() {
+        let metadata = AudioMetadataReader.read(url: tempDir)
+        XCTAssertNil(metadata, "Expected nil for a directory URL")
+    }
+
+    // MARK: - Helpers
+
+    /// Writes a short silent PCM WAV file at the requested sample rate using
+    /// AVAudioFile, so tests don't depend on external fixtures.
+    private func writeSilentWAV(
+        to url: URL,
+        sampleRate: Double,
+        channels: AVAudioChannelCount,
+        bitsPerChannel: UInt32
+    ) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: sampleRate,
+            channels: channels,
+            interleaved: false
+        )!
+
+        // AVAudioFile writes WAV when the extension is .wav.
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+
+        let frameCount = AVAudioFrameCount(sampleRate * 0.25) // 0.25s of silence
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            XCTFail("Failed to allocate PCM buffer")
+            return
+        }
+        buffer.frameLength = frameCount
+        // Zero-filled buffer = silence. Int16 format already zeroed by init.
+
+        try file.write(from: buffer)
+    }
+}

--- a/LosslessSwitcherTests/BrowserLogParserTests.swift
+++ b/LosslessSwitcherTests/BrowserLogParserTests.swift
@@ -1,0 +1,126 @@
+//
+//  BrowserLogParserTests.swift
+//  LosslessSwitcherTests
+//
+//  Verifies BrowserCoreMediaParser only emits stats from known browser process
+//  names, accepts credible sample-rate lines, and ignores lines without a
+//  parseable rate.
+//
+
+import XCTest
+@testable import LosslessSwitcher
+
+final class BrowserLogParserTests: XCTestCase {
+
+    private let parser = BrowserCoreMediaParser()
+
+    // MARK: - Positive cases: browser lines with a sample rate
+
+    func testBrowserCoreMediaSampleRateParses() {
+        // Simulate a Chrome CoreMedia fpfs line with [SampleRate 48000].
+        let line = "2026-07-04 09:00:00.000 Chrome[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 48000] [BitDepth 16]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+
+        XCTAssertNotNil(stat, "Expected a stat for a browser line with [SampleRate 48000]")
+        XCTAssertEqual(stat?.sampleRate, 48000)
+        XCTAssertEqual(stat?.priority, 3)
+        XCTAssertEqual(stat?.processName, "Chrome")
+    }
+
+    func testBrowserAudioQueueSampleRateParses() {
+        // Simulate a Safari Creating AudioQueue line with sampleRate:44100.0.
+        let line = "2026-07-04 09:00:00.000 Safari[1234:5678] Creating AudioQueue sampleRate:44100.0"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+
+        XCTAssertNotNil(stat, "Expected a stat for a Safari AudioQueue line with sampleRate:44100.0")
+        XCTAssertEqual(stat?.sampleRate, 44100)
+        XCTAssertEqual(stat?.priority, 3)
+        XCTAssertEqual(stat?.processName, "Safari")
+    }
+
+    func testFirefoxSampleRateParses() {
+        let line = "2026-07-04 09:00:00.000 Firefox[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 96000]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNotNil(stat)
+        XCTAssertEqual(stat?.sampleRate, 96000)
+        XCTAssertEqual(stat?.processName, "Firefox")
+    }
+
+    func testArcSampleRateParses() {
+        let line = "2026-07-04 09:00:00.000 Arc[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 44100]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNotNil(stat)
+        XCTAssertEqual(stat?.sampleRate, 44100)
+        XCTAssertEqual(stat?.processName, "Arc")
+    }
+
+    // MARK: - Negative cases: no rate or out-of-range rate
+
+    func testBrowserParserIgnoresUnknownRateLines() {
+        // Browser audio line WITHOUT a sample rate.
+        let line = "2026-07-04 09:00:00.000 Chrome[1234:5678] some audio buffer status update without rate"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNil(stat, "Lines without a parseable sample rate must return nil")
+    }
+
+    func testBrowserParserIgnoresOutOfRangeRate() {
+        // Rate outside the supported 8000...384000 window.
+        let line = "2026-07-04 09:00:00.000 Chrome[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 100]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNil(stat, "Out-of-range sample rate (100 Hz) must be ignored")
+    }
+
+    // MARK: - Negative cases: non-browser process
+
+    func testBrowserParserIgnoresNonBrowserProcesses() {
+        // Music (Apple Music) line with a sample rate — must NOT be picked up by
+        // the browser parser. The generic CoreMediaParser handles Music.
+        let line = "2026-07-04 09:00:00.000 Music[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 48000]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNil(stat, "Non-browser processes must not be handled by BrowserCoreMediaParser")
+    }
+
+    func testBrowserParserIgnoresIINA() {
+        let line = "2026-07-04 09:00:00.000 IINA[1234:5678] [fpfs_ReportAudioPlaybackThroughFigLog] [SampleRate 96000]"
+        let stat = parser.parse(line: line, currentTrackName: nil)
+        XCTAssertNil(stat, "IINA is not a browser and must not be handled by BrowserCoreMediaParser")
+    }
+
+    // MARK: - Helper functions
+
+    func testIsBrowserProcessRecognizesKnownBrowsers() {
+        XCTAssertTrue(isBrowserProcess("Safari"))
+        XCTAssertTrue(isBrowserProcess("Chrome"))
+        XCTAssertTrue(isBrowserProcess("Google Chrome"))
+        XCTAssertTrue(isBrowserProcess("Brave Browser"))
+        XCTAssertTrue(isBrowserProcess("Microsoft Edge"))
+        XCTAssertTrue(isBrowserProcess("Arc"))
+        XCTAssertTrue(isBrowserProcess("Firefox"))
+        // Case-insensitive
+        XCTAssertTrue(isBrowserProcess("safari"))
+        XCTAssertTrue(isBrowserProcess("FIREFOX"))
+    }
+
+    func testIsBrowserProcessRejectsNonBrowsers() {
+        XCTAssertFalse(isBrowserProcess("Music"))
+        XCTAssertFalse(isBrowserProcess("IINA"))
+        XCTAssertFalse(isBrowserProcess("Xcode"))
+        XCTAssertFalse(isBrowserProcess(nil))
+        XCTAssertFalse(isBrowserProcess(""))
+    }
+
+    func testExtractProcessNameFromLogLine() {
+        let line = "2026-07-04 09:00:00.000 Chrome[1234:5678] some message"
+        XCTAssertEqual(extractProcessName(from: line), "Chrome")
+    }
+
+    func testExtractProcessNameReturnsNilForMalformedLine() {
+        let line = "no brackets here"
+        // When there's no `[`, the whole preamble is used; last word is "here".
+        // The function returns the last whitespace-separated token before `[`.
+        // If there's no `[` at all, `line.range(of: "[")` is nil and it returns nil.
+        // But wait — looking at the implementation: it only extracts if `[` is found.
+        XCTAssertNil(extractProcessName(from: "no brackets here"),
+                     "Without a `[` delimiter the process name cannot be extracted")
+    }
+}

--- a/LosslessSwitcherTests/IINAOpenFileProviderTests.swift
+++ b/LosslessSwitcherTests/IINAOpenFileProviderTests.swift
@@ -1,0 +1,218 @@
+//
+//  IINAOpenFileProviderTests.swift
+//  LosslessSwitcherTests
+//
+//  Tests the lsof output parser (pure seam) and the provider's duplicate
+//  suppression behavior. These tests do NOT require IINA to be installed or
+//  running — they use fixture lsof output strings and the reducer directly.
+//
+
+import XCTest
+import Combine
+import AVFoundation
+@testable import LosslessSwitcher
+
+final class IINAOpenFileProviderTests: XCTestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        cancellables.removeAll()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("IINAProviderTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - LsofMediaPathParser
+
+    func testLsofParserKeepsFlacAndDropsAppResources() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let fixture = """
+        p12345
+        f1234
+        n/Applications/IINA.app/Contents/Resources/something.flac
+        n/Users/test/Music/album/track.flac
+        n/Library/Application Support/com.colliderli.iina/cache.dat
+        """
+        let urls = LsofMediaPathParser.mediaPaths(from: fixture, homeDirectory: home)
+        XCTAssertEqual(urls.count, 1, "Only the user-track FLAC should survive; app resources must be dropped")
+        XCTAssertTrue(urls.first?.path.hasSuffix("track.flac") ?? false)
+    }
+
+    func testLsofParserKeepsMostRelevantMediaExtensions() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let fixture = """
+        p12345
+        n/Users/test/song.flac
+        n/Users/test/song.wav
+        n/Users/test/song.aiff
+        n/Users/test/song.m4a
+        n/Users/test/song.mp3
+        n/Users/test/song.ogg
+        n/Users/test/song.opus
+        n/Users/test/song.mp4
+        n/Users/test/song.mkv
+        n/Users/test/song.mov
+        n/Users/test/subtitle.srt
+        n/Users/test/notes.txt
+        n/Users/test/cover.jpg
+        """
+        let urls = LsofMediaPathParser.mediaPaths(from: fixture, homeDirectory: home)
+        let exts = urls.map { ($0.path as NSString).pathExtension.lowercased() }
+        XCTAssertEqual(exts.sorted(), ["aiff", "flac", "m4a", "mkv", "mov", "mp3", "mp4", "ogg", "opus", "wav"].sorted(),
+                       "Parser must keep all supported media extensions and drop subtitles/text/images")
+    }
+
+    func testLsofParserDeduplicatesPaths() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let fixture = """
+        p12345
+        n/Users/test/track.flac
+        n/Users/test/track.flac
+        n/Users/test/track.flac
+        """
+        let urls = LsofMediaPathParser.mediaPaths(from: fixture, homeDirectory: home)
+        XCTAssertEqual(urls.count, 1, "Duplicate paths must be collapsed to a single URL")
+    }
+
+    func testLsofParserExpandsTildePrefixedPaths() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let fixture = """
+        p12345
+        n~/Music/track.flac
+        """
+        let urls = LsofMediaPathParser.mediaPaths(from: fixture, homeDirectory: home)
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertTrue(urls.first?.path.hasPrefix(home.path) ?? false,
+                      "Tilde-prefixed paths must be expanded against the provided home directory")
+    }
+
+    // MARK: - Provider candidate emission + duplicate suppression (Task 9)
+
+    func testProviderCandidateUsesMetadataReaderResult() throws {
+        // Generate a real WAV fixture so AudioMetadataReader returns a real rate.
+        // This verifies the metadata path the provider would use to build a
+        // DetectionCandidate, without starting the provider's timer (which
+        // requires IINA to be running and would be non-deterministic in CI).
+        let wavURL = tempDir.appendingPathComponent("provider-test-44100.wav")
+        try writeSilentWAV(to: wavURL, sampleRate: 44100)
+
+        let metadata = AudioMetadataReader.read(url: wavURL)
+        XCTAssertEqual(metadata?.sampleRate ?? 0, 44100, accuracy: 0.001,
+                       "Provider would emit this rate for the open file")
+        XCTAssertNotNil(metadata?.bitDepth,
+                       "Provider would include bit depth in the candidate")
+
+        // Verify the provider can be constructed without side effects.
+        let provider = IINAOpenFileProvider()
+        XCTAssertEqual(provider.identifier, "IINAOpenFileProvider")
+    }
+
+    func testRepeatedSameIINAStatDoesNotTriggerRepeatedGeneration() {
+        // Task 9: verifies the reducer suppresses repeated same-rate
+        // lower-or-equal-confidence candidates so latestStats does not flash.
+        var reducer = DetectionCandidateReducer()
+        let now = Date()
+        let stat = CMPlayerStats(sampleRate: 44100, bitDepth: 16, date: now, priority: 7, processName: "IINA", trackName: "track.flac")
+        let candidate = DetectionCandidate(
+            stats: stat,
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(4),
+            diagnostic: "IINA local file"
+        )
+
+        XCTAssertTrue(reducer.shouldAccept(candidate, now: now), "First candidate must be accepted")
+        // Identical candidate with the same confidence and rate — must be rejected.
+        XCTAssertFalse(reducer.shouldAccept(candidate, now: now), "Identical re-emission must be suppressed")
+        XCTAssertFalse(reducer.shouldAccept(candidate, now: now), "Repeated identical emission must stay suppressed")
+    }
+
+    func testReducerAcceptsHigherConfidenceReplacement() {
+        var reducer = DetectionCandidateReducer()
+        let now = Date()
+        let lowPriority = DetectionCandidate(
+            stats: CMPlayerStats(sampleRate: 44100, bitDepth: 24, date: now, priority: 2, processName: "CoreMedia"),
+            sourceKind: .coreMediaLog,
+            confidence: 2,
+            expiresAt: now.addingTimeInterval(4),
+            diagnostic: "low"
+        )
+        let highPriority = DetectionCandidate(
+            stats: CMPlayerStats(sampleRate: 44100, bitDepth: 16, date: now, priority: 7, processName: "IINA"),
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(4),
+            diagnostic: "high"
+        )
+
+        XCTAssertTrue(reducer.shouldAccept(lowPriority, now: now))
+        XCTAssertTrue(reducer.shouldAccept(highPriority, now: now),
+                      "Higher-confidence candidate must replace the accepted one even at the same rate")
+        XCTAssertFalse(reducer.shouldAccept(highPriority, now: now),
+                       "After accepting the higher-confidence candidate, a duplicate must be suppressed")
+    }
+
+    func testReducerRejectsExpiredCandidate() {
+        var reducer = DetectionCandidateReducer()
+        let now = Date()
+        let expired = DetectionCandidate(
+            stats: CMPlayerStats(sampleRate: 44100, bitDepth: 16, date: now, priority: 7),
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(-1), // already expired
+            diagnostic: "stale"
+        )
+        XCTAssertFalse(reducer.shouldAccept(expired, now: now), "Expired candidate must be rejected")
+    }
+
+    func testReducerAcceptsNewerDifferentRate() {
+        var reducer = DetectionCandidateReducer()
+        let now = Date()
+        let first = DetectionCandidate(
+            stats: CMPlayerStats(sampleRate: 44100, bitDepth: 16, date: now, priority: 7),
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(4),
+            diagnostic: "44.1k"
+        )
+        let second = DetectionCandidate(
+            stats: CMPlayerStats(sampleRate: 96000, bitDepth: 24, date: now.addingTimeInterval(1), priority: 7),
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(4),
+            diagnostic: "96k"
+        )
+
+        XCTAssertTrue(reducer.shouldAccept(first, now: now))
+        XCTAssertTrue(reducer.shouldAccept(second, now: now),
+                       "Newer candidate with a materially different rate must be accepted")
+    }
+
+    // MARK: - Helpers
+
+    private func writeSilentWAV(to url: URL, sampleRate: Double) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: sampleRate,
+            channels: 2,
+            interleaved: false
+        )!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let frameCount = AVAudioFrameCount(sampleRate * 0.25)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            XCTFail("Failed to allocate PCM buffer")
+            return
+        }
+        buffer.frameLength = frameCount
+        try file.write(from: buffer)
+    }
+}

--- a/LosslessSwitcherTests/OutputDevicesPrebufferTests.swift
+++ b/LosslessSwitcherTests/OutputDevicesPrebufferTests.swift
@@ -24,6 +24,10 @@ final class TestOutputDevicesNoMonitoring: OutputDevices {
     override func startMusicAppMonitoring() {
         // 测试中禁用 Music 通知监听，避免与测试用例耦合
     }
+
+    override func startLogStreamer() {
+        // 测试中禁用真实日志流和 provider，避免系统日志干扰注入的测试数据
+    }
 }
 
 final class TestOutputDevicesWithMonitoring: OutputDevices {
@@ -39,6 +43,10 @@ final class TestOutputDevicesWithMonitoring: OutputDevices {
 
     override func startHeartbeat() {
         // 测试中禁用心跳，避免后台触发 switchLatestSampleRate 影响结果
+    }
+
+    override func startLogStreamer() {
+        // 测试中禁用真实日志流和 provider，避免系统日志干扰注入的测试数据
     }
 }
 
@@ -64,6 +72,10 @@ final class TestOutputDevicesFormatSelection: OutputDevices {
         // 测试中禁用 Music 通知监听，避免与测试用例耦合
     }
 
+    override func startLogStreamer() {
+        // 测试中禁用真实日志流和 provider，避免系统日志干扰注入的测试数据
+    }
+
     override func getFormats(bestStat: CMPlayerStats, device: AudioDevice) -> [AudioStreamBasicDescription]? {
         return injectedFormats
     }
@@ -74,6 +86,7 @@ final class TestOutputDevicesFormatSelection: OutputDevices {
 
     override func updateSampleRate(_ sampleRate: Float64, bitDepth: Int?) {
         updatedSampleRate = sampleRate
+        previousSampleRate = sampleRate
     }
 }
 
@@ -91,8 +104,13 @@ final class TestOutputDevicesPrebufferApply: OutputDevices {
     override func startHeartbeat() {
     }
 
+    override func startLogStreamer() {
+        // 测试中禁用真实日志流和 provider
+    }
+
     override func updateSampleRate(_ sampleRate: Float64, bitDepth: Int?) {
         updatedSampleRate = sampleRate
+        previousSampleRate = sampleRate
     }
 }
 
@@ -104,8 +122,12 @@ final class TestOutputDevicesMusicDowngrade: OutputDevices {
     override func getDeviceSampleRate() {}
     override func startHeartbeat() {}
     override func startMusicAppMonitoring() {}
+    override func startLogStreamer() {
+        // 测试中禁用真实日志流和 provider
+    }
     override func updateSampleRate(_ sampleRate: Float64, bitDepth: Int?) {
         updatedSampleRate = sampleRate
+        previousSampleRate = sampleRate
     }
 }
 
@@ -115,6 +137,8 @@ final class OutputDevicesPrebufferTests: XCTestCase {
         RunLoop.main.run(until: Date().addingTimeInterval(1.0))
         LogStreamer.shared.stop()
         LogStreamer.shared.resetDebugStateForTests()
+        LogStreamer.shared.resetProviderStateForTests()
+        SampleRatePolicy.shared.resetStateForTests()
         RunLoop.main.run(until: Date().addingTimeInterval(0.2))
     }
 
@@ -568,7 +592,9 @@ final class OutputDevicesPrebufferTests: XCTestCase {
     }
 
     private func readPendingStat(in devices: OutputDevices) -> CMPlayerStats? {
-        return readValue(named: "pendingNextTrackStat", from: devices)
+        // pendingNextTrackStat was migrated from OutputDevices to
+        // SampleRatePolicy.shared; read it from the policy singleton.
+        return readValue(named: "pendingNextTrackStat", from: SampleRatePolicy.shared)
     }
 
     private func readValue<T>(named name: String, from object: Any) -> T? {

--- a/Quality.xcodeproj/project.pbxproj
+++ b/Quality.xcodeproj/project.pbxproj
@@ -40,6 +40,13 @@
 		ECFEB1CD2F67D0E900785AE6 /* LogStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA1B2C3D4E5F60100000001 /* LogStreamer.swift */; };
 		ECFEB1CE2F67D0E900785AE6 /* SampleRatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA1B2C3D4E5F60200000001 /* SampleRatePolicy.swift */; };
 		ECFEB1CF2F67D0E900785AE6 /* LogParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA1B2C3D4E5F60300000001 /* LogParser.swift */; };
+		F1A1B2C3D4E5F6A200000001 /* AudioSampleRateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000001 /* AudioSampleRateProvider.swift */; };
+		F1A1B2C3D4E5F6A200000002 /* DetectionCandidateReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000002 /* DetectionCandidateReducer.swift */; };
+		F1A1B2C3D4E5F6A200000003 /* AudioMetadataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000003 /* AudioMetadataReader.swift */; };
+		F1A1B2C3D4E5F6A200000004 /* IINAOpenFileProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000004 /* IINAOpenFileProvider.swift */; };
+		F1A1B2C3D4E5F6A300000005 /* AudioMetadataReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000005 /* AudioMetadataReaderTests.swift */; };
+		F1A1B2C3D4E5F6A300000006 /* IINAOpenFileProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000006 /* IINAOpenFileProviderTests.swift */; };
+		F1A1B2C3D4E5F6A300000007 /* BrowserLogParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A1B2C3D4E5F6A100000007 /* BrowserLogParserTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +103,13 @@
 		BFA1B2C3D4E5F60400000001 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		BFA1B2C3D4E5F60500000001 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		DEADB921F53E47ABA955B3E3 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = System/Library/Frameworks/XCTest.framework; sourceTree = SDKROOT; };
+		F1A1B2C3D4E5F6A100000001 /* AudioSampleRateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSampleRateProvider.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000002 /* DetectionCandidateReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectionCandidateReducer.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000003 /* AudioMetadataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMetadataReader.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000004 /* IINAOpenFileProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IINAOpenFileProvider.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000005 /* AudioMetadataReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMetadataReaderTests.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000006 /* IINAOpenFileProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IINAOpenFileProviderTests.swift; sourceTree = "<group>"; };
+		F1A1B2C3D4E5F6A100000007 /* BrowserLogParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserLogParserTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +163,7 @@
 		1272AA96280DBB4900FD72BA /* Quality */ = {
 			isa = PBXGroup;
 			children = (
+				F1A1B2C3D4E5F6A400000001 /* Detection */,
 				BFA1B2C3D4E5F60500000001 /* Logger.swift */,
 				BFA1B2C3D4E5F60400000001 /* AppConfig.swift */,
 				BFA1B2C3D4E5F60100000001 /* LogStreamer.swift */,
@@ -187,10 +202,24 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		F1A1B2C3D4E5F6A400000001 /* Detection */ = {
+			isa = PBXGroup;
+			children = (
+				F1A1B2C3D4E5F6A100000001 /* AudioSampleRateProvider.swift */,
+				F1A1B2C3D4E5F6A100000002 /* DetectionCandidateReducer.swift */,
+				F1A1B2C3D4E5F6A100000003 /* AudioMetadataReader.swift */,
+				F1A1B2C3D4E5F6A100000004 /* IINAOpenFileProvider.swift */,
+			);
+			path = Detection;
+			sourceTree = "<group>";
+		};
 		F0AA751A88794AC88F7762E6 /* LosslessSwitcherTests */ = {
 			isa = PBXGroup;
 			children = (
 				61E764AF84A24EBA81590227 /* OutputDevicesPrebufferTests.swift */,
+				F1A1B2C3D4E5F6A100000005 /* AudioMetadataReaderTests.swift */,
+				F1A1B2C3D4E5F6A100000006 /* IINAOpenFileProviderTests.swift */,
+				F1A1B2C3D4E5F6A100000007 /* BrowserLogParserTests.swift */,
 			);
 			path = LosslessSwitcherTests;
 			sourceTree = "<group>";
@@ -326,6 +355,10 @@
 				1272AA98280DBB4900FD72BA /* QualityApp.swift in Sources */,
 				BF342D802E0947890032F398 /* SampleRateLabel.swift in Sources */,
 				127C972D281FCF000087313B /* AppVersion.swift in Sources */,
+				F1A1B2C3D4E5F6A200000001 /* AudioSampleRateProvider.swift in Sources */,
+				F1A1B2C3D4E5F6A200000002 /* DetectionCandidateReducer.swift in Sources */,
+				F1A1B2C3D4E5F6A200000003 /* AudioMetadataReader.swift in Sources */,
+				F1A1B2C3D4E5F6A200000004 /* IINAOpenFileProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -333,12 +366,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ECFEB1CB2F67D0E900785AE6 /* Logger.swift in Sources */,
-				ECFEB1CC2F67D0E900785AE6 /* AppConfig.swift in Sources */,
-				ECFEB1CD2F67D0E900785AE6 /* LogStreamer.swift in Sources */,
-				ECFEB1CE2F67D0E900785AE6 /* SampleRatePolicy.swift in Sources */,
-				ECFEB1CF2F67D0E900785AE6 /* LogParser.swift in Sources */,
 				A992D9690EDD4353BA7F1C53 /* OutputDevicesPrebufferTests.swift in Sources */,
+				F1A1B2C3D4E5F6A300000005 /* AudioMetadataReaderTests.swift in Sources */,
+				F1A1B2C3D4E5F6A300000006 /* IINAOpenFileProviderTests.swift in Sources */,
+				F1A1B2C3D4E5F6A300000007 /* BrowserLogParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Quality/Detection/AudioMetadataReader.swift
+++ b/Quality/Detection/AudioMetadataReader.swift
@@ -1,0 +1,79 @@
+//
+//  AudioMetadataReader.swift
+//  Quality
+//
+//  Reads source sample rate (and bit depth when available) directly from a
+//  local media file. Used by the IINA local-file provider to detect sample
+//  rates without relying on IINA audio output options.
+//
+//  Uses AVAudioFile (AVFoundation) to open and inspect the file's native
+//  audio format, which avoids the need for IINA audio-exclusive/device options
+//  and works for FLAC/WAV/AIFF/M4A and other AVFoundation-supported formats.
+//
+
+import Foundation
+import AVFoundation
+import CoreAudioTypes
+
+struct AudioMetadata {
+    let sampleRate: Double
+    let bitDepth: Int?
+    let codecDescription: String
+}
+
+enum AudioMetadataReader {
+    /// Supported sample-rate window. Anything outside this range is treated as
+    /// suspicious (corrupt metadata or non-audio file) and rejected.
+    static let supportedSampleRateRange: ClosedRange<Double> = 8000...384000
+
+    /// Reads audio metadata from a local file URL.
+    /// - Returns: `AudioMetadata` when the file can be opened and reports a
+    ///   plausible sample rate; `nil` for directories, missing files, or
+    ///   unsupported/undecodable files.
+    static func read(url: URL) -> AudioMetadata? {
+        // Reject directories outright.
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), !isDir.boolValue else {
+            return nil
+        }
+
+        // AVAudioFile(forReading:) throws for unsupported/corrupt files.
+        guard let audioFile = try? AVAudioFile(forReading: url) else {
+            return nil
+        }
+
+        // fileFormat describes the actual stored format of the file on disk
+        // (as opposed to processingFormat, which is the converted format).
+        let format = audioFile.fileFormat
+        let sampleRate = format.sampleRate
+        guard supportedSampleRateRange.contains(sampleRate) else { return nil }
+
+        // Access the underlying AudioStreamBasicDescription for bit depth and
+        // format ID. AVAudioFormat.streamDescription returns a pointer to the
+        // canonical description.
+        let desc = format.streamDescription.pointee
+        let bitDepth: Int? = desc.mBitsPerChannel > 0 ? Int(desc.mBitsPerChannel) : nil
+        let codecDescription = fourCharCodeToString(desc.mFormatID)
+
+        return AudioMetadata(
+            sampleRate: sampleRate,
+            bitDepth: bitDepth,
+            codecDescription: codecDescription
+        )
+    }
+
+    /// Converts a FourCharCode (OSType) into a human-readable 4-character string,
+    /// filtering non-printable bytes. Used purely for diagnostics.
+    private static func fourCharCodeToString(_ code: UInt32) -> String {
+        let bytes: [UInt8] = [
+            UInt8((code >> 24) & 0xFF),
+            UInt8((code >> 16) & 0xFF),
+            UInt8((code >> 8) & 0xFF),
+            UInt8(code & 0xFF)
+        ]
+        let printable = bytes.map { byte -> String in
+            (0x20...0x7E).contains(byte) ? String(format: "%c", byte) : "?"
+        }
+        return printable.joined()
+    }
+}

--- a/Quality/Detection/AudioSampleRateProvider.swift
+++ b/Quality/Detection/AudioSampleRateProvider.swift
@@ -1,0 +1,38 @@
+//
+//  AudioSampleRateProvider.swift
+//  Quality
+//
+//  Provider-based sample-rate detection. Providers publish DetectionCandidate
+//  values that the LogStreamer reducer filters before they reach latestStats.
+//
+
+import Combine
+import Foundation
+
+/// Kind of source that produced a detection candidate. Mirrors the priority table
+/// in the implementation plan (IINA local file = 7, CoreAudio log = 5, browser log = 3, etc.).
+enum DetectionSourceKind: String {
+    case coreAudioLog
+    case coreMediaLog
+    case iinaLocalFile
+    case browserLog
+}
+
+/// A candidate sample-rate observation emitted by a provider.
+struct DetectionCandidate {
+    let stats: CMPlayerStats
+    let sourceKind: DetectionSourceKind
+    let confidence: Int
+    let expiresAt: Date
+    let diagnostic: String
+}
+
+/// Protocol for sources that can publish sample-rate candidates independently of the
+/// `/usr/bin/log stream` pipeline. Providers are registered with LogStreamer and
+/// started/stopped alongside the log process.
+protocol AudioSampleRateProvider: AnyObject {
+    var identifier: String { get }
+    var candidatePublisher: AnyPublisher<DetectionCandidate, Never> { get }
+    func start()
+    func stop()
+}

--- a/Quality/Detection/DetectionCandidateReducer.swift
+++ b/Quality/Detection/DetectionCandidateReducer.swift
@@ -1,0 +1,42 @@
+//
+//  DetectionCandidateReducer.swift
+//  Quality
+//
+//  Filters provider candidates before they reach latestStats. Rejects stale
+//  candidates and repeated same-rate lower-confidence candidates so that
+//  continuous playback does not trigger flashing or redundant switches.
+//
+
+import Foundation
+
+struct DetectionCandidateReducer {
+    private(set) var lastAccepted: DetectionCandidate?
+
+    mutating func shouldAccept(_ candidate: DetectionCandidate, now: Date = Date()) -> Bool {
+        // Reject already-expired candidates outright.
+        guard candidate.expiresAt >= now else { return false }
+
+        // If we have no live accepted candidate, accept this one.
+        guard let current = lastAccepted, current.expiresAt >= now else {
+            lastAccepted = candidate
+            return true
+        }
+
+        let newStats = candidate.stats
+        let oldStats = current.stats
+        let isNewer = newStats.date >= oldStats.date
+        let isHigherConfidence = candidate.confidence > current.confidence
+        let isDifferentRate = abs(newStats.sampleRate - oldStats.sampleRate) >= 100
+
+        // Accept when the new candidate is strictly more confident, OR when it is
+        // both newer and represents a materially different sample rate. Same-rate
+        // lower-or-equal-confidence duplicates are suppressed to avoid flashing.
+        let accept = isHigherConfidence || (isNewer && isDifferentRate)
+        if accept { lastAccepted = candidate }
+        return accept
+    }
+
+    mutating func reset() {
+        lastAccepted = nil
+    }
+}

--- a/Quality/Detection/IINAOpenFileProvider.swift
+++ b/Quality/Detection/IINAOpenFileProvider.swift
@@ -1,0 +1,228 @@
+//
+//  IINAOpenFileProvider.swift
+//  Quality
+//
+//  Discovers the currently-opened local media file in the IINA process and
+//  emits a DetectionCandidate built from the file's audio metadata. Does not
+//  require IINA `audio-exclusive` or `audio-device` mpv options — it reads the
+//  source file directly via AudioMetadataReader.
+//
+
+import Combine
+import Foundation
+import AppKit
+import OSLog
+
+/// Pure parser for `/usr/sbin/lsof -Fn -p <pid>` output. Extracted as a
+/// standalone, side-effect-free helper so it can be unit-tested with fixture
+/// strings without spawning processes.
+struct LsofMediaPathParser {
+    /// Extensions we treat as playable media IINA might have open.
+    static let mediaExtensions: Set<String> = [
+        "flac", "wav", "aif", "aiff", "m4a", "mp3", "ogg", "opus", "mp4", "mkv", "mov"
+    ]
+
+    /// Paths that begin with any of these prefixes are IINA-internal resources
+    /// (app bundle, support files) and must be excluded from candidates.
+    static let excludedPathPrefixes: [String] = [
+        "/Applications/IINA.app",
+        "/Library/Application Support/com.colliderli.iina",
+    ]
+
+    /// Subtitle extensions that should never be treated as audio sources.
+    static let subtitleExtensions: Set<String> = ["srt", "ass", "ssa", "vtt", "sub"]
+
+    /// Parses `lsof -Fn` output into media-file URLs.
+    /// - Parameters:
+    ///   - output: Raw stdout of `lsof -Fn -p <pid>`.
+    ///   - homeDirectory: The home directory used to expand `~`-prefixed paths
+    ///     that lsof sometimes emits. Pass `FileManager.default.homeDirectoryForCurrentUser`.
+    /// - Returns: Distinct media-file URLs, in the order they first appeared.
+    static func mediaPaths(from output: String, homeDirectory: URL) -> [URL] {
+        var seen = Set<String>()
+        var results: [URL] = []
+
+        for line in output.components(separatedBy: .newlines) {
+            // `lsof -Fn` prefixes file paths with `n`.
+            guard line.hasPrefix("n") else { continue }
+            let raw = String(line.dropFirst())
+            if raw.isEmpty { continue }
+
+            // Expand a leading `~` to the supplied home directory.
+            let expanded: String
+            if raw.hasPrefix("~") {
+                expanded = homeDirectory.path + String(raw.dropFirst())
+            } else {
+                expanded = raw
+            }
+
+            // Skip IINA-internal resources.
+            if excludedPathPrefixes.contains(where: { expanded.hasPrefix($0) }) { continue }
+
+            // Skip subtitle-only files.
+            let pathExtension = (expanded as NSString).pathExtension.lowercased()
+            if pathExtension.isEmpty { continue }
+            if subtitleExtensions.contains(pathExtension) { continue }
+            guard mediaExtensions.contains(pathExtension) else { continue }
+
+            // De-duplicate by path string.
+            if seen.contains(expanded) { continue }
+            seen.insert(expanded)
+            results.append(URL(fileURLWithPath: expanded))
+        }
+
+        return results
+    }
+}
+
+/// Provider that watches the IINA process for open media files and publishes
+/// sample-rate candidates derived from the file's own audio metadata.
+final class IINAOpenFileProvider: AudioSampleRateProvider {
+    let identifier = "IINAOpenFileProvider"
+
+    private let candidateSubject = PassthroughSubject<DetectionCandidate, Never>()
+    var candidatePublisher: AnyPublisher<DetectionCandidate, Never> {
+        candidateSubject.eraseToAnyPublisher()
+    }
+
+    /// IINA's bundle identifier.
+    static let iinaBundleID = "com.colliderli.iina"
+
+    /// Minimum interval between `lsof` invocations for a given PID, to keep
+    /// resource usage bounded during continuous playback.
+    static let lsofInterval: TimeInterval = 2.0
+
+    /// Candidate expiry window. A candidate remains valid for this long after
+    /// it was emitted before the reducer treats it as stale.
+    static let candidateTTL: TimeInterval = 4.0
+
+    /// Suppression window: an identical (path, sampleRate, bitDepth) tuple is
+    /// not re-emitted within this interval, preventing repeated same-file
+    /// candidate churn during continuous IINA playback.
+    static let duplicateSuppressionWindow: TimeInterval = 10.0
+
+    private var timer: DispatchSourceTimer?
+    private let queue = DispatchQueue(label: "com.vincent-neo.LosslessSwitcher.iina-provider", qos: .utility)
+    private var lastLsofAt: [pid_t: Date] = [:]
+
+    // Task 9 — duplicate-suppression cache.
+    private var lastEmittedPath: String?
+    private var lastEmittedSampleRate: Double?
+    private var lastEmittedBitDepth: Int?
+    private var lastEmittedAt: Date?
+
+    init() {}
+
+    func start() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 1.0, repeating: Self.lsofInterval)
+        timer.setEventHandler { [weak self] in
+            self?.pollOnce()
+        }
+        timer.resume()
+        self.timer = timer
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+        queue.async { [weak self] in
+            self?.lastLsofAt.removeAll()
+            self?.lastEmittedPath = nil
+            self?.lastEmittedSampleRate = nil
+            self?.lastEmittedBitDepth = nil
+            self?.lastEmittedAt = nil
+        }
+    }
+
+    private func pollOnce() {
+        let now = Date()
+        let pids = Self.runningIINAPIDs()
+        guard !pids.isEmpty else { return }
+
+        for pid in pids {
+            // Throttle lsof invocations per PID.
+            if let last = lastLsofAt[pid], now.timeIntervalSince(last) < Self.lsofInterval {
+                continue
+            }
+            lastLsofAt[pid] = now
+
+            guard let output = Self.runLsof(pid: pid) else { continue }
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            let mediaPaths = LsofMediaPathParser.mediaPaths(from: output, homeDirectory: home)
+            for url in mediaPaths {
+                guard let metadata = AudioMetadataReader.read(url: url) else { continue }
+                emitCandidate(url: url, metadata: metadata, now: now)
+                // Only the first readable media file per poll wins; this matches
+                // the plan's "first stable candidate path that returns a sample rate".
+                break
+            }
+        }
+    }
+
+    private func emitCandidate(url: URL, metadata: AudioMetadata, now: Date) {
+        let path = url.path
+
+        // Task 9 — suppress identical re-emissions within the suppression window.
+        let isSameTuple = (lastEmittedPath == path)
+            && (lastEmittedSampleRate.map { abs($0 - metadata.sampleRate) < 1.0 } ?? false)
+            && (lastEmittedBitDepth == metadata.bitDepth)
+        if let lastAt = lastEmittedAt, isSameTuple, now.timeIntervalSince(lastAt) < Self.duplicateSuppressionWindow {
+            return
+        }
+        lastEmittedPath = path
+        lastEmittedSampleRate = metadata.sampleRate
+        lastEmittedBitDepth = metadata.bitDepth
+        lastEmittedAt = now
+
+        let stat = CMPlayerStats(
+            sampleRate: metadata.sampleRate,
+            bitDepth: metadata.bitDepth ?? 24,
+            date: now,
+            priority: 7,
+            processName: "IINA",
+            trackName: url.lastPathComponent
+        )
+
+        let candidate = DetectionCandidate(
+            stats: stat,
+            sourceKind: .iinaLocalFile,
+            confidence: 7,
+            expiresAt: now.addingTimeInterval(Self.candidateTTL),
+            diagnostic: "IINA local file: \(url.lastPathComponent) [\(metadata.codecDescription)]"
+        )
+
+        Logger.streamer.info("[IINAProvider] \(candidate.diagnostic, privacy: .public) sr=\(metadata.sampleRate, privacy: .public)")
+        candidateSubject.send(candidate)
+    }
+
+    // MARK: - Process discovery (extracted for testability of the seam)
+
+    /// Returns PIDs of running IINA apps by bundle id. Empty when IINA is not running.
+    static func runningIINAPIDs() -> [pid_t] {
+        let apps = NSRunningApplication.runningApplications(withBundleIdentifier: iinaBundleID)
+        return apps.compactMap { $0.processIdentifier }
+    }
+
+    /// Runs `/usr/sbin/lsof -Fn -p <pid>` and returns its stdout, or nil on failure.
+    static func runLsof(pid: pid_t) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-Fn", "-p", String(pid)]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe() // discard stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Quality/LogParser.swift
+++ b/Quality/LogParser.swift
@@ -102,7 +102,24 @@ struct CoreMediaParser: LogParser {
     }
 }
 
-private func extractProcessName(from line: String) -> String? {
+/// Browser process names whose CoreMedia/CoreAudio log lines should be treated
+/// as browser playback candidates. Matched case-insensitively by `isBrowserProcess`.
+let browserProcessNames: [String] = [
+    "Safari",
+    "Google Chrome",
+    "Chrome",
+    "Brave Browser",
+    "Brave",
+    "Microsoft Edge",
+    "Edge",
+    "Arc",
+    "Firefox"
+]
+
+/// Extracts the process name from the preamble of a `/usr/bin/log` compact line.
+/// Made internal (rather than private) so parsers and tests can share the same
+/// extraction logic.
+func extractProcessName(from line: String) -> String? {
     if let range = line.range(of: "[") {
         let preamble = line[..<range.lowerBound]
         if let lastWord = preamble.components(separatedBy: .whitespaces).last {
@@ -112,7 +129,67 @@ private func extractProcessName(from line: String) -> String? {
     return nil
 }
 
-private func isMusicProcess(_ name: String?) -> Bool {
+/// Returns true when the process name is Apple Music or iTunes.
+func isMusicProcess(_ name: String?) -> Bool {
     guard let name = name?.lowercased() else { return false }
     return name == "music" || name == "itunes"
+}
+
+/// Returns true when the process name matches a known browser. Case-insensitive.
+func isBrowserProcess(_ name: String?) -> Bool {
+    guard let name = name?.lowercased() else { return false }
+    return browserProcessNames.contains { $0.lowercased() == name }
+}
+
+/// Parser for CoreMedia/CoreAudio sample-rate log lines emitted by browser
+/// processes (Safari, Chrome, Brave, Edge, Arc, Firefox). Emits a candidate
+/// only when the line contains a parseable sample rate within the supported
+/// range. Lines that mention browser audio but expose no rate return nil so
+/// the generic CoreMediaParser can still handle them (or ignore them).
+struct BrowserCoreMediaParser: LogParser {
+    let identifier = "BrowserCoreMedia"
+
+    static let supportedSampleRateRange: ClosedRange<Double> = 8000...384000
+
+    private static let fpfsRateRegex = try? NSRegularExpression(pattern: #"\[SampleRate\s*([0-9]+)\]"#, options: [])
+    private static let audioQueueRateRegex = try? NSRegularExpression(pattern: #"sampleRate:\s*([0-9.]+)"#, options: [])
+
+    func parse(line: String, currentTrackName: String?) -> CMPlayerStats? {
+        let processName = extractProcessName(from: line)
+        guard isBrowserProcess(processName) else { return nil }
+
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+
+        // Reuse the same patterns the generic CoreMediaParser uses, but only for
+        // browser process names. Priority 3 sits above generic CoreMedia (priority 2)
+        // but below CoreAudio Apple Lossless (priority 5).
+        if let match = BrowserCoreMediaParser.fpfsRateRegex?.firstMatch(in: line, options: [], range: range),
+           let rateRange = Range(match.range(at: 1), in: line) {
+            let raw = line[rateRange]
+            if let sr = Double(raw), Self.supportedSampleRateRange.contains(sr) {
+                var stat = CMPlayerStats(sampleRate: sr, bitDepth: 24, date: Date(), priority: 3)
+                stat.processName = processName
+                stat.trackName = currentTrackName
+                return stat
+            }
+            return nil
+        }
+
+        if let match = BrowserCoreMediaParser.audioQueueRateRegex?.firstMatch(in: line, options: [], range: range),
+           let rateRange = Range(match.range(at: 1), in: line) {
+            let raw = line[rateRange]
+            if let sr = Double(raw), Self.supportedSampleRateRange.contains(sr) {
+                var stat = CMPlayerStats(sampleRate: sr, bitDepth: 24, date: Date(), priority: 3)
+                stat.processName = processName
+                stat.trackName = currentTrackName
+                return stat
+            }
+            return nil
+        }
+
+        // Browser audio line without a parseable sample rate — return nil so the
+        // generic CoreMediaParser does not pick it up either (it has the same
+        // patterns and would otherwise double-handle).
+        return nil
+    }
 }

--- a/Quality/LogStreamer.swift
+++ b/Quality/LogStreamer.swift
@@ -27,12 +27,46 @@ class LogStreamer: ObservableObject {
     private var currentTrackSignature: String?
     private var currentTrackStartTime: Date?
     
-    private var parsers: [LogParser] = [CoreAudioParser(), CoreMediaParser()]
-    
+    private var parsers: [LogParser] = [CoreAudioParser(), BrowserCoreMediaParser(), CoreMediaParser()]
+
+    // MARK: - Provider aggregation (Task 4)
+    private var providers: [AudioSampleRateProvider] = []
+    private var providerCancellables: [AnyCancellable] = []
+    private var candidateReducer = DetectionCandidateReducer()
+    private var registeredProviderIDs = Set<String>()
+    #if DEBUG
+    /// When false, `start()` will not start registered providers. Set to false
+    /// by `resetProviderStateForTests()` so that `OutputDevices.init()` calling
+    /// `LogStreamer.shared.start()` during tests does not spawn the IINA
+    /// provider's lsof timer against a real running IINA process.
+    private var providersShouldStart = true
+    #endif
+
     private init() {}
 
     func register(parser: LogParser) {
         parsers.append(parser)
+    }
+
+    /// Registers an external sample-rate provider. Duplicate identifiers are
+    /// silently ignored so repeated `OutputDevices` construction (including in
+    /// tests) cannot stack the same provider.
+    func register(provider: AudioSampleRateProvider) {
+        if registeredProviderIDs.contains(provider.identifier) { return }
+        registeredProviderIDs.insert(provider.identifier)
+        providers.append(provider)
+        let cancellable = provider.candidatePublisher.sink { [weak self] candidate in
+            self?.appendCandidate(candidate)
+        }
+        providerCancellables.append(cancellable)
+    }
+
+    /// Routes a provider-emitted candidate through the reducer before it can
+    /// reach `latestStats`. Stale and duplicate same-rate lower-confidence
+    /// candidates are rejected here.
+    func appendCandidate(_ candidate: DetectionCandidate) {
+        guard candidateReducer.shouldAccept(candidate) else { return }
+        appendDebugStat(candidate.stats)
     }
 
 #if DEBUG
@@ -43,6 +77,21 @@ class LogStreamer: ObservableObject {
         currentTrackID = nil
         currentTrackName = nil
         currentTrackSignature = nil
+    }
+
+    /// Clears all registered providers, their cancellables, and the reducer
+    /// state. Also sets `providersShouldStart = false` so that the subsequent
+    /// `OutputDevices.init()` → `LogStreamer.shared.start()` call does not
+    /// start the IINA provider's lsof timer during tests (which would emit real
+    /// candidates if IINA happens to be running on the test machine).
+    func resetProviderStateForTests() {
+        providers.forEach { $0.stop() }
+        providers.removeAll()
+        providerCancellables.forEach { $0.cancel() }
+        providerCancellables.removeAll()
+        registeredProviderIDs.removeAll()
+        candidateReducer.reset()
+        providersShouldStart = false
     }
 #endif
 
@@ -173,13 +222,21 @@ class LogStreamer: ObservableObject {
         do {
             try process.run()
             Logger.streamer.info("[LogStreamer] Log stream started successfully.")
+            #if DEBUG
+            if providersShouldStart {
+                providers.forEach { $0.start() }
+            }
+            #else
+            providers.forEach { $0.start() }
+            #endif
         } catch {
             Logger.streamer.error("[LogStreamer] Failed to run log process: \(error, privacy: .public)")
         }
     }
-    
+
     func stop() {
         isExplicitlyStopped = true
+        providers.forEach { $0.stop() }
         stopProcess()
     }
 

--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -35,7 +35,7 @@ class OutputDevices: ObservableObject {
     
     private var processQueue = DispatchQueue(label: "processQueue", qos: .userInitiated)
     
-    private var previousSampleRate: Float64?
+    var previousSampleRate: Float64?
     private var lastDetectedSampleRate: Float64?
     
     private var heartbeatCancellable: AnyCancellable?
@@ -108,20 +108,32 @@ class OutputDevices: ObservableObject {
         enableBitDepthDetectionCancellable = Defaults.shared.$userPreferBitDepthDetection.sink(receiveValue: { newValue in
             self.enableBitDepthDetection = newValue
         })
-        
+
+        self.startLogStreamer()
+
+        self.startHeartbeat()
+        self.startMusicAppMonitoring()
+    }
+
+    /// Starts the `LogStreamer` and subscribes to its `latestStats` publisher.
+    /// Extracted as an overridable method so test subclasses can suppress the
+    /// real log stream (and provider side effects) to keep tests deterministic.
+    func startLogStreamer() {
         if #available(macOS 15.0, *) {
+            // Register the IINA local-file provider before starting the log
+            // stream. Provider registration is idempotent (guarded by
+            // `registeredProviderIDs`), so repeated `OutputDevices` construction
+            // in tests will not stack duplicate providers.
+            LogStreamer.shared.register(provider: IINAOpenFileProvider())
             LogStreamer.shared.start()
         }
-        
+
         logStreamerCancellable = LogStreamer.shared.$latestStats
             .dropFirst()
             .receive(on: processQueue)
             .sink { [weak self] _ in
                 self?.switchLatestSampleRate()
             }
-        
-        self.startHeartbeat()
-        self.startMusicAppMonitoring()
     }
     
     func startMusicAppMonitoring() {
@@ -405,7 +417,7 @@ class OutputDevices: ObservableObject {
             }
             self.currentSampleRate = readableSampleRate
 
-            if let bitDepth = bitDepth, bitDepth > 0 {
+            if let bitDepth = bitDepth, bitDepth > 0, self.currentBitDepth != bitDepth {
                 self.currentBitDepth = bitDepth
             }
         }

--- a/Quality/SampleRatePolicy.swift
+++ b/Quality/SampleRatePolicy.swift
@@ -42,6 +42,31 @@ class SampleRatePolicy: ObservableObject {
 
     private init() {}
 
+#if DEBUG
+    /// Resets all mutable state so tests start from a clean slate. Without this,
+    /// the singleton's `lastTrackChangeDate`, `isMusicPlaying`, and pending
+    /// downgrade fields leak across test cases and produce non-deterministic
+    /// results.
+    func resetStateForTests() {
+        lastTrackChangeDate = Date.distantPast
+        lastKnownTrackID = nil
+        lastKnownTrackName = nil
+        currentTrackPlayedTime = 0
+        lastPlaybackSnapshot = nil
+        isMusicPlaying = false
+        pendingNextTrackStat = nil
+        pendingNextTrackStatLastSeen = nil
+        pendingMusicDowngradeStat = nil
+        pendingMusicDowngradeDetectedAt = nil
+        pendingMusicDowngradeLastSeen = nil
+        lastMusicLogAt = nil
+        lastMusicHighRateAt = nil
+        lastProcessedGeneration = 0
+        lastProcessedStatDate = nil
+        lastDetectedSampleRate = nil
+    }
+#endif
+
     @discardableResult
     func updateMusicState(isPlaying: Bool, trackID: String?, trackName: String?) -> Bool {
         let wasPlaying = self.isMusicPlaying

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@
    - 作为备用检测源
    - 提供基本的采样率信息
 
+4. **IINA 本地文件检测（新增）**
+   - 直接读取 IINA 当前打开的本地媒体文件元数据
+   - 支持 FLAC/WAV/AIFF/M4A/MP3/OGG/Opus 等格式
+   - **无需配置 IINA 的 `audio-exclusive` 或 `audio-device` 选项**
+   - 通过 `lsof` 发现 IINA 进程打开的文件，使用 AVFoundation 读取采样率
+   - 优先级最高（7），当 IINA 播放本地文件时优先使用文件元数据
+
+5. **浏览器/YouTube Music 检测（新增）**
+   - 解析 Safari/Chrome/Brave/Edge/Arc/Firefox 的 CoreMedia/CoreAudio 日志
+   - 仅当日志中包含可解析的采样率时才触发切换
+   - **未知采样率不会触发切换**，避免误切换
+   - 优先级为 3，高于通用 CoreMedia 日志但低于 CoreAudio Apple Lossless
+
 ### 主要特性
 
 - 🎵 **通用兼容**：支持所有音频播放器，不限于 Apple Music
@@ -58,6 +71,8 @@
 
 - ⚠️ 本版本**不显示曲目信息**（歌名、艺术家等），仅专注于采样率切换
 - ✅ 相比原版更轻量，功耗更低
+- 🎬 **IINA 本地文件检测**：通过读取 IINA 进程打开的文件元数据来检测采样率。无需配置 IINA 的 `audio-exclusive` 或 `audio-device` 选项。DRM/流媒体/网络内容可能无法暴露源文件采样率。
+- 🌐 **浏览器/YouTube Music 检测**：依赖 CoreMedia/CoreAudio 日志中暴露的采样率。如果浏览器仅输出混合/重采样的系统输出或没有采样率日志，LosslessSwitcher 不会切换。未知采样率会被忽略以防止随机切换。
 
 ### 版本信息
 
@@ -100,6 +115,19 @@ The application detects audio sample rates through:
    - Serves as a fallback detection source
    - Provides basic sample rate information
 
+4. **IINA Local File Detection (New)**
+   - Reads audio metadata directly from the media file IINA has open
+   - Supports FLAC/WAV/AIFF/M4A/MP3/OGG/Opus and other AVFoundation-supported formats
+   - **No IINA `audio-exclusive` or `audio-device` mpv options required**
+   - Discovers open files via `lsof` and reads sample rate using AVFoundation
+   - Highest priority (7) — file metadata takes precedence when IINA plays a local file
+
+5. **Browser/YouTube Music Detection (New)**
+   - Parses CoreMedia/CoreAudio log lines from Safari, Chrome, Brave, Edge, Arc, and Firefox
+   - Switches only when the log line contains a parseable sample rate in the supported range (8 kHz–384 kHz)
+   - **Unknown sample rates are ignored** to prevent false/random switching
+   - Priority 3 — above generic CoreMedia logs but below CoreAudio Apple Lossless
+
 ### Key Features
 
 - 🎵 **Universal Compatibility**: Supports all audio players, not limited to Apple Music
@@ -125,6 +153,8 @@ The application detects audio sample rates through:
 
 - ⚠️ This version **does not display track information** (song name, artist, etc.), focusing solely on sample rate switching
 - ✅ More lightweight and lower power consumption compared to the original
+- 🎬 **IINA local file detection**: Works by reading the audio metadata of the file IINA has open. No IINA `audio-exclusive` or `audio-device` configuration is required. DRM/streamed/network-only content may not expose the source file's sample rate.
+- 🌐 **Browser/YouTube Music detection**: Depends on CoreMedia/CoreAudio sample-rate logs being emitted by the browser. If the browser only outputs mixed/resampled system audio or no sample-rate log, LosslessSwitcher will not switch. Unknown rates are ignored to prevent random switching.
 
 ### Version Information
 

--- a/docs/turingskills/plans/2026-07-04-provider-detection-iina-browser.md
+++ b/docs/turingskills/plans/2026-07-04-provider-detection-iina-browser.md
@@ -1,0 +1,810 @@
+# Provider-Based IINA and Browser Detection Implementation Plan
+
+> **For agentic executors:** Use `subagent-driven-development` or `executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add non-invasive provider-based sample-rate detection for IINA local media playback and YouTube Music/browser playback without forcing IINA or browser audio output settings.
+
+**Approach:** Preserve the current CoreAudio/CoreMedia log stream and wrap detection behind provider boundaries. Add an IINA local-file provider that discovers the currently opened media file from the IINA process and reads the file's audio metadata directly, plus browser log parsers that switch only when CoreMedia/CoreAudio logs contain a credible sample rate. Merge provider outputs into the existing `CMPlayerStats` pipeline with explicit priority, confidence, TTL, and stale-data safeguards.
+
+**Tech Stack:** Swift 6.2.3, SwiftUI, Combine, XCTest, Xcode 26.2, `SimplyCoreAudio`, `Sweep`, `/usr/bin/log`, `/usr/sbin/lsof`, AudioToolbox/AVFoundation for media metadata, `gh` CLI for fork/PR operations.
+
+## Current Repository State
+
+**Fork:** `https://github.com/bibimoni/LosslessSwitcher`
+
+**Local clone:** `/Users/distiled/Dev/exen-mcp/LosslessSwitcher`
+
+**Upstream:** `https://github.com/FantasticSkyBaby/LosslessSwitcher`
+
+**Relevant existing files:**
+- `Quality/LogStreamer.swift` — launches `/usr/bin/log stream`, parses lines, publishes `latestStats`.
+- `Quality/LogParser.swift` — contains `CoreAudioParser` and `CoreMediaParser`.
+- `Quality/CMPlayerStuff.swift` — defines `CMPlayerStats` and legacy log parsing helpers.
+- `Quality/OutputDevices.swift` — subscribes to `LogStreamer.shared.$latestStats` and applies sample-rate switches.
+- `Quality/SampleRatePolicy.swift` — prevents stale/prebuffer/downgrade mis-switches.
+- `LosslessSwitcherTests/OutputDevicesPrebufferTests.swift` — existing XCTest suite.
+
+## Required Behavior
+
+1. Apple Music behavior remains unchanged.
+2. IINA local media playback does not require IINA `audio-exclusive` or `audio-device` mpv options.
+3. IINA local FLAC/WAV/AIFF/M4A files can be detected by reading source-file audio metadata.
+4. Browser/YouTube Music switches only when CoreMedia/CoreAudio logs expose a clear browser sample rate.
+5. Unknown browser rates do not trigger a switch.
+6. Stale provider data expires and cannot repeatedly flash/switch the output device.
+7. Existing selected-output-device behavior remains unchanged: LosslessSwitcher switches its selected/default output device, not the playback application's device routing.
+
+## Detection Priority Rules
+
+| Priority | Source | Applies When | Action |
+|---:|---|---|---|
+| 7 | IINA local file metadata | IINA process has an open supported local media file and file metadata contains sample rate | Use sample rate; bit depth if available, else current/default bit-depth behavior |
+| 5 | CoreAudio Apple Lossless decoder logs | Existing `ACAppleLosslessDecoder.cpp Input format` lines | Preserve current behavior |
+| 3 | Browser/CoreMedia logs | Process name is Safari/Chrome/Brave/Edge/Arc/Firefox and line contains `SampleRate` or `sampleRate` | Use only if rate is in supported range and line is fresh |
+| 2 | Existing CoreMedia AudioQueue logs | Existing `fpfs_ReportAudioPlaybackThroughFigLog` / `Creating AudioQueue` lines | Preserve behavior but tag source |
+| 0 | Unknown/ambiguous | Any source without a parseable rate | Ignore and log debug note only |
+
+## Implementation Tasks
+
+### Task 1: Create Working Branch and Verify Fork Remotes
+
+**Inputs:** local clone at `/Users/distiled/Dev/exen-mcp/LosslessSwitcher`
+**Outputs:** branch `feature/provider-detection-iina-browser`
+**Tools:** `git`, `gh`
+
+- [ ] **Step: Verify active GitHub account and fork remote**
+
+```bash
+gh auth status
+gh repo view bibimoni/LosslessSwitcher --json name,owner,url,defaultBranchRef
+git remote -v
+```
+
+Expected:
+- `bibimoni` is active.
+- `origin` points to `https://github.com/bibimoni/LosslessSwitcher.git`.
+- `upstream` points to `https://github.com/FantasticSkyBaby/LosslessSwitcher.git`.
+
+- [ ] **Step: Create implementation branch**
+
+```bash
+git switch -c feature/provider-detection-iina-browser
+```
+
+Expected: `git branch --show-current` prints `feature/provider-detection-iina-browser`.
+
+### Task 2: Repair/Verify Local Xcode Build Frontier
+
+**Inputs:** `Quality.xcodeproj`
+**Outputs:** confirmed build/test command availability or documented toolchain blocker
+**Tools:** `xcodebuild`, `xcode-select`, `swift`
+
+- [ ] **Step: Verify toolchain versions**
+
+```bash
+xcode-select -p
+xcodebuild -version
+swift --version
+```
+
+Expected:
+- Xcode path: `/Applications/Xcode.app/Contents/Developer`
+- Xcode reports a version.
+- Swift reports an Apple Swift version.
+
+- [ ] **Step: Verify project listing**
+
+```bash
+xcodebuild -list -project Quality.xcodeproj
+```
+
+Expected success output includes scheme `LosslessSwitcher`. If it fails with the local `IDESimulatorFoundation` plug-in error, run the repair step immediately.
+
+- [ ] **Step: Repair Xcode first-launch content if required**
+
+```bash
+sudo xcodebuild -runFirstLaunch
+xcodebuild -list -project Quality.xcodeproj
+```
+
+Expected: second command lists project targets/schemes. If it still fails, stop implementation and record the exact Xcode error in `.opencode/integration-status.md`; code changes can continue, but final build/test cannot be claimed until this gate passes.
+
+### Task 3: Add Provider Model Types
+
+**Inputs:** `Quality/CMPlayerStuff.swift`, `Quality/LogStreamer.swift`
+**Outputs:** provider protocol and metadata structs compiled into app target
+**Tools:** Swift, Xcode project file edits
+
+- [ ] **Step: Add `Quality/Detection/AudioSampleRateProvider.swift`**
+
+Create:
+
+```swift
+import Foundation
+import Combine
+
+enum DetectionSourceKind: String {
+    case coreAudioLog
+    case coreMediaLog
+    case iinaLocalFile
+    case browserLog
+}
+
+struct DetectionCandidate {
+    let stats: CMPlayerStats
+    let sourceKind: DetectionSourceKind
+    let confidence: Int
+    let expiresAt: Date
+    let diagnostic: String
+}
+
+protocol AudioSampleRateProvider: AnyObject {
+    var identifier: String { get }
+    var candidatePublisher: AnyPublisher<DetectionCandidate, Never> { get }
+    func start()
+    func stop()
+}
+```
+
+Expected: file exists and has no references to UI or hardware switching.
+
+- [ ] **Step: Add file to Xcode target**
+
+Use Xcode or edit `Quality.xcodeproj/project.pbxproj` to include `AudioSampleRateProvider.swift` in the `LosslessSwitcher` target.
+
+Verify:
+
+```bash
+grep -n "AudioSampleRateProvider.swift" Quality.xcodeproj/project.pbxproj
+```
+
+Expected: at least one `PBXFileReference` and one `PBXSourcesBuildPhase` entry.
+
+### Task 4: Refactor `LogStreamer` into Provider Aggregator Without Changing Existing Behavior
+
+**Inputs:** `Quality/LogStreamer.swift`
+**Outputs:** `LogStreamer` can accept external provider candidates and still parses existing log lines
+**Tools:** Swift, Combine
+
+- [ ] **Step: Add candidate reducer**
+
+Add `Quality/Detection/DetectionCandidateReducer.swift`:
+
+```swift
+struct DetectionCandidateReducer {
+    private(set) var lastAccepted: DetectionCandidate?
+
+    mutating func shouldAccept(_ candidate: DetectionCandidate, now: Date = Date()) -> Bool {
+        guard candidate.expiresAt >= now else { return false }
+        guard let current = lastAccepted, current.expiresAt >= now else {
+            lastAccepted = candidate
+            return true
+        }
+        let newStats = candidate.stats
+        let oldStats = current.stats
+        let isNewer = newStats.date >= oldStats.date
+        let isHigherConfidence = candidate.confidence > current.confidence
+        let isDifferentRate = abs(newStats.sampleRate - oldStats.sampleRate) >= 100
+        let accept = isHigherConfidence || (isNewer && isDifferentRate)
+        if accept { lastAccepted = candidate }
+        return accept
+    }
+}
+```
+
+Expected: stale candidates and repeated same-rate lower-confidence candidates are rejected before `latestStats` changes.
+
+- [ ] **Step: Add provider storage to `LogStreamer`**
+
+Modify `LogStreamer`:
+
+```swift
+private var providers: [AudioSampleRateProvider] = []
+private var providerCancellables: [AnyCancellable] = []
+private var candidateReducer = DetectionCandidateReducer()
+```
+
+Add:
+
+```swift
+func register(provider: AudioSampleRateProvider) {
+    providers.append(provider)
+    let cancellable = provider.candidatePublisher.sink { [weak self] candidate in
+        self?.appendCandidate(candidate)
+    }
+    providerCancellables.append(cancellable)
+}
+
+func appendCandidate(_ candidate: DetectionCandidate) {
+    guard candidateReducer.shouldAccept(candidate) else { return }
+    appendDebugStat(candidate.stats)
+}
+```
+
+Expected: existing `appendDebugStat(_:)` remains the single route to `latestStats`, and candidates pass through `DetectionCandidateReducer` first.
+
+- [ ] **Step: Start/stop providers with log stream**
+
+At the end of `start()` after successful process start, call `providers.forEach { $0.start() }`.
+In `stop()`, call `providers.forEach { $0.stop() }` before clearing state.
+
+Verify by build once Task 2 passes.
+
+### Task 5: Add Media Metadata Reader for Local Files
+
+**Inputs:** local media file URL
+**Outputs:** source sample rate and bit depth candidate
+**Tools:** AudioToolbox or AVFoundation, XCTest fixtures
+
+- [ ] **Step: Add `Quality/Detection/AudioMetadataReader.swift`**
+
+Implement:
+
+```swift
+struct AudioMetadata {
+    let sampleRate: Double
+    let bitDepth: Int?
+    let codecDescription: String
+}
+
+enum AudioMetadataReader {
+    static func read(url: URL) -> AudioMetadata?
+}
+```
+
+Implementation rules:
+- Use `AudioFileOpenURL` and `AudioFileGetProperty(kAudioFilePropertyDataFormat)` first.
+- Return `mSampleRate` when it is between `8000...384000`.
+- Return `mBitsPerChannel` only when greater than `0`.
+- Close `AudioFileID` after reading.
+- Return `nil` for directories, missing files, and unsupported files.
+
+- [ ] **Step: Add metadata reader tests**
+
+Add `LosslessSwitcherTests/AudioMetadataReaderTests.swift` with generated temporary WAV fixtures:
+
+```swift
+func testReadsSampleRateFromGeneratedWavFixture()
+func testReturnsNilForUnsupportedTextFile()
+```
+
+Generate WAV fixture in test using `AVAudioFile` or write a short PCM WAV header. Expected: 44_100 Hz fixture returns `44100` within `0.001` tolerance.
+
+### Task 6: Add IINA Open-File Provider
+
+**Inputs:** running app `com.colliderli.iina`; open media file paths from `lsof`
+**Outputs:** `DetectionCandidate` with `sourceKind = .iinaLocalFile`, priority/confidence 7
+**Tools:** `NSWorkspace`, `/usr/sbin/lsof`, `AudioMetadataReader`, Combine timer
+
+- [ ] **Step: Add `Quality/Detection/IINAOpenFileProvider.swift`**
+
+Implement provider:
+- Find running IINA apps by bundle ID `com.colliderli.iina`.
+- For each PID, run `/usr/sbin/lsof -Fn -p <pid>` no more than once every 2 seconds.
+- Parse lines beginning with `n` into file paths.
+- Keep paths with extensions: `flac`, `wav`, `aif`, `aiff`, `m4a`, `mp3`, `ogg`, `opus`, `mp4`, `mkv`, `mov`.
+- Exclude paths under `/Applications/IINA.app/`, `~/Library/Application Support/com.colliderli.iina/`, and subtitle extensions.
+- Read metadata from the first stable candidate path that returns a sample rate.
+- Emit `CMPlayerStats(sampleRate: metadata.sampleRate, bitDepth: metadata.bitDepth ?? 24, date: Date(), priority: 7)` with `processName = "IINA"`, `trackName = url.lastPathComponent`.
+- Set `expiresAt = Date().addingTimeInterval(4)`.
+
+- [ ] **Step: Add parser seam for tests**
+
+Extract lsof parsing into a pure helper:
+
+```swift
+struct LsofMediaPathParser {
+    static func mediaPaths(from output: String, homeDirectory: URL) -> [URL]
+}
+```
+
+Expected: helper has no process execution side effects.
+
+- [ ] **Step: Add IINA provider tests**
+
+Add `LosslessSwitcherTests/IINAOpenFileProviderTests.swift`:
+
+```swift
+func testLsofParserKeepsFlacAndDropsAppResources()
+func testLsofParserKeepsMostRelevantMediaExtensions()
+func testProviderCandidateUsesMetadataReaderResult()
+```
+
+Expected: tests do not require IINA to be installed or running; they use fixture lsof output strings.
+
+### Task 7: Add Browser Log Parser Provider Behavior
+
+**Inputs:** CoreMedia/CoreAudio log lines from browser processes
+**Outputs:** browser stats only for credible sample-rate lines
+**Tools:** Swift regex, existing `LogParser`
+
+- [ ] **Step: Extend `LogParser.swift` with source helpers**
+
+Change private helpers to internal functions so tests can call them:
+
+```swift
+func extractProcessName(from line: String) -> String?
+func isMusicProcess(_ name: String?) -> Bool
+func isBrowserProcess(_ name: String?) -> Bool
+```
+
+Browser process names:
+`Safari`, `Google Chrome`, `Chrome`, `Brave Browser`, `Brave`, `Microsoft Edge`, `Edge`, `Arc`, `Firefox`.
+
+- [ ] **Step: Add `BrowserCoreMediaParser`**
+
+Implement parser in `LogParser.swift`:
+
+```swift
+struct BrowserCoreMediaParser: LogParser { ... }
+```
+
+Rules:
+- Parse only if `isBrowserProcess(extractProcessName(from: line))` is true.
+- Reuse patterns `\[SampleRate\s*([0-9]+)\]` and `sampleRate:\s*([0-9.]+)`.
+- Accept rates from `8000...384000`.
+- Emit `CMPlayerStats(sampleRate: sr, bitDepth: 24, date: Date(), priority: 3)` with `processName` set to browser name.
+- Return `nil` for lines that mention browser audio but do not include a parseable sample rate.
+
+- [ ] **Step: Register browser parser before generic CoreMedia parser**
+
+Update `LogStreamer.parsers`:
+
+```swift
+private var parsers: [LogParser] = [CoreAudioParser(), BrowserCoreMediaParser(), CoreMediaParser()]
+```
+
+Expected: existing Apple Music/CoreAudio behavior remains first and unchanged; browser-specific CoreMedia lines are handled before generic `CoreMediaParser` can consume them.
+
+- [ ] **Step: Add browser parser tests**
+
+Add `LosslessSwitcherTests/BrowserLogParserTests.swift`:
+
+```swift
+func testBrowserCoreMediaSampleRateParses()
+func testBrowserParserIgnoresUnknownRateLines()
+func testBrowserParserIgnoresNonBrowserProcesses()
+```
+
+Expected: browser parser only emits stats from browser process names.
+
+### Task 8: Register Providers During App Startup
+
+**Inputs:** `OutputDevices.init()` or app bootstrap path
+**Outputs:** IINA provider registered once
+**Tools:** Swift
+
+- [ ] **Step: Register IINA provider before `LogStreamer.shared.start()`**
+
+In `OutputDevices.init()`, before `LogStreamer.shared.start()`:
+
+```swift
+LogStreamer.shared.register(provider: IINAOpenFileProvider())
+```
+
+Guard against duplicate registration by adding `registeredProviderIDs` to `LogStreamer`:
+
+```swift
+private var registeredProviderIDs = Set<String>()
+```
+
+Expected: repeated `OutputDevices` construction in tests does not register duplicate providers.
+
+- [ ] **Step: Disable provider side effects in existing tests**
+
+Existing test subclasses call `LogStreamer.shared.stop()` in `setUp`. Add a debug-only reset method to clear providers if needed:
+
+```swift
+#if DEBUG
+func resetProviderStateForTests() { ... }
+#endif
+```
+
+Expected: existing tests remain deterministic.
+
+### Task 9: Stabilize Candidate Expiry and Flash Behavior
+
+**Inputs:** `LogStreamer`, `OutputDevices`, `SampleRatePolicy`
+**Outputs:** stale provider candidates ignored; UI does not flash repeatedly for same rate
+**Tools:** Swift, XCTest
+
+- [ ] **Step: Prevent repeated same-file candidate churn**
+
+In `IINAOpenFileProvider`, cache last emitted tuple `(path, sampleRate, bitDepth)` and emit again only when tuple changes or after 10 seconds.
+
+Expected: continuous IINA playback does not publish the same stat every 2 seconds.
+
+- [ ] **Step: Add same-rate no-flash regression test**
+
+Add test to existing suite or new provider suite:
+
+```swift
+func testRepeatedSameIINAStatDoesNotTriggerRepeatedGeneration()
+```
+
+Expected: second identical provider candidate is suppressed before `LogStreamer.latestStats` changes.
+
+### Task 10: Unit Test Full Parser and Provider Surface
+
+**Inputs:** all new test files
+**Outputs:** passing XCTest parser/provider suite
+**Tools:** `xcodebuild test`
+
+- [ ] **Step: Run focused XCTest suite**
+
+```bash
+xcodebuild test \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -destination 'platform=macOS' \
+  -only-testing:LosslessSwitcherTests/AudioMetadataReaderTests \
+  -only-testing:LosslessSwitcherTests/IINAOpenFileProviderTests \
+  -only-testing:LosslessSwitcherTests/BrowserLogParserTests
+```
+
+Expected: exit 0; output contains `** TEST SUCCEEDED **`.
+
+- [ ] **Step: Run existing regression tests**
+
+```bash
+xcodebuild test \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -destination 'platform=macOS'
+```
+
+Expected: exit 0; output contains `** TEST SUCCEEDED **`.
+
+### Task 11: Build Debug and Release Apps
+
+**Inputs:** app source and Xcode project
+**Outputs:** built `.app` products in DerivedData
+**Tools:** `xcodebuild`
+
+- [ ] **Step: Clean build folder**
+
+```bash
+xcodebuild clean \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Debug
+```
+
+Expected: exit 0; output contains `** CLEAN SUCCEEDED **`.
+
+- [ ] **Step: Build Debug**
+
+```bash
+xcodebuild build \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Debug \
+  -destination 'platform=macOS'
+```
+
+Expected: exit 0; output contains `** BUILD SUCCEEDED **`.
+
+- [ ] **Step: Build Release**
+
+```bash
+xcodebuild build \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Release \
+  -destination 'platform=macOS'
+```
+
+Expected: exit 0; output contains `** BUILD SUCCEEDED **`.
+
+### Task 12: Manual Local Deployment for E2E Testing
+
+**Inputs:** Debug or Release app product
+**Outputs:** installed local test copy of LosslessSwitcher
+**Tools:** `xcodebuild`, Finder or `open`, macOS Activity Monitor if needed
+
+- [ ] **Step: Locate built app**
+
+```bash
+APP_PATH=$(xcodebuild -showBuildSettings \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  | awk -F'= ' '/ TARGET_BUILD_DIR / {dir=$2} / WRAPPER_NAME / {name=$2} END {print dir "/" name}')
+test -d "$APP_PATH" && printf '%s\n' "$APP_PATH"
+```
+
+Expected: prints a path ending in `LosslessSwitcher.app`.
+
+- [ ] **Step: Stop currently installed app before E2E**
+
+```bash
+osascript -e 'tell application id "com.vincent-neo.LosslessSwitcher" to quit' || true
+pgrep -fl LosslessSwitcher || true
+```
+
+Expected: no running `LosslessSwitcher` process after quit.
+
+- [ ] **Step: Launch built test app**
+
+```bash
+open "$APP_PATH"
+sleep 3
+pgrep -fl LosslessSwitcher
+```
+
+Expected: one running `LosslessSwitcher` process from the build output path.
+
+### Task 13: E2E Test IINA Local FLAC Without IINA Audio Config
+
+**Inputs:** running test LosslessSwitcher, IINA with `userOptions = []`, local FLAC fixtures
+**Outputs:** selected/default output sample rate switches to source file rate
+**Tools:** IINA, `ffmpeg`, `system_profiler`, `log show`
+
+- [ ] **Step: Verify IINA does not force audio config**
+
+```bash
+python3 - <<'PY'
+import plistlib, os
+p=os.path.expanduser('~/Library/Preferences/com.colliderli.iina.plist')
+with open(p,'rb') as f:
+    d=plistlib.load(f)
+print(d.get('userOptions', []))
+PY
+```
+
+Expected: printed list does not contain `audio-exclusive` or `audio-device`.
+
+- [ ] **Step: Generate local FLAC fixtures**
+
+```bash
+mkdir -p /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e
+ffmpeg -hide_banner -loglevel error -y -f lavfi -i anullsrc=r=44100:cl=stereo -t 12 -sample_fmt s16 /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-44k.flac
+ffmpeg -hide_banner -loglevel error -y -f lavfi -i anullsrc=r=96000:cl=stereo -t 12 -sample_fmt s16 /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-96k.flac
+ffprobe -v error -show_entries stream=sample_rate -of default=nw=1 /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-44k.flac
+ffprobe -v error -show_entries stream=sample_rate -of default=nw=1 /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-96k.flac
+```
+
+Expected: prints `sample_rate=44100` and `sample_rate=96000`.
+
+- [ ] **Step: Play 44.1 kHz file in IINA and verify output device rate**
+
+```bash
+open -a IINA /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-44k.flac
+sleep 6
+system_profiler SPAudioDataType | grep -A8 -E 'RETRO NANO|Default Output Device|Current SampleRate'
+```
+
+Expected: the LosslessSwitcher-selected or macOS default output device reports `Current SampleRate: 44100` when that device supports 44.1 kHz.
+
+- [ ] **Step: Play 96 kHz file in IINA and verify output device rate**
+
+```bash
+open -a IINA /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/lossless-e2e/e2e-96k.flac
+sleep 6
+system_profiler SPAudioDataType | grep -A8 -E 'RETRO NANO|Default Output Device|Current SampleRate'
+```
+
+Expected: the same output device reports `Current SampleRate: 96000` when it supports 96 kHz.
+
+- [ ] **Step: Verify debug logs identify IINA provider**
+
+```bash
+log show --last 2m --style compact --predicate 'process == "LosslessSwitcher" AND eventMessage CONTAINS[c] "IINA"'
+```
+
+Expected: log line includes IINA source path or diagnostic from `IINAOpenFileProvider` and the detected sample rate.
+
+### Task 14: E2E Test YouTube Music / Browser Detection
+
+**Inputs:** running test LosslessSwitcher, browser playback from YouTube Music
+**Outputs:** browser detection switches only when a sample-rate log exists; otherwise no switch and debug notes are clear
+**Tools:** Chrome/Safari/browser, `log stream`, `log show`, `system_profiler`
+
+- [ ] **Step: Start log observation before browser playback**
+
+```bash
+log stream --style compact --predicate '(subsystem == "com.apple.coremedia" OR subsystem == "com.apple.coreaudio") AND (process CONTAINS "Chrome" OR process CONTAINS "Safari" OR process CONTAINS "Brave" OR process CONTAINS "Arc" OR eventMessage CONTAINS[c] "SampleRate" OR eventMessage CONTAINS[c] "sampleRate")'
+```
+
+Expected: command streams logs; keep it open during the browser playback check.
+
+- [ ] **Step: Play YouTube Music in one browser**
+
+Manual action: open `https://music.youtube.com`, play a track for at least 30 seconds.
+
+Expected:
+- If CoreMedia/CoreAudio emits browser sample-rate logs, LosslessSwitcher debug logs show browser detection and one switch to the detected rate.
+- If no sample-rate logs appear, LosslessSwitcher does not switch and does not flash repeatedly.
+
+- [ ] **Step: Verify no random switch when browser rate is unknown**
+
+```bash
+system_profiler SPAudioDataType | grep -A8 -E 'RETRO NANO|Default Output Device|Current SampleRate'
+log show --last 2m --style compact --predicate 'process == "LosslessSwitcher" AND (eventMessage CONTAINS[c] "browser" OR eventMessage CONTAINS[c] "unknown" OR eventMessage CONTAINS[c] "Switch")'
+```
+
+Expected: no repeated switching loop. Any browser-related log must either include a sample rate or state that browser rate is unknown/ignored.
+
+### Task 15: Regression E2E for Apple Music
+
+**Inputs:** running test LosslessSwitcher, Apple Music playback with known local/lossless content
+**Outputs:** Apple Music sample-rate switching remains unchanged
+**Tools:** Apple Music, `system_profiler`, `log show`
+
+- [ ] **Step: Play known Apple Music/local lossless content**
+
+Manual action: play a track that previously switched correctly.
+
+Verify:
+
+```bash
+sleep 8
+system_profiler SPAudioDataType | grep -A8 -E 'RETRO NANO|Default Output Device|Current SampleRate'
+log show --last 2m --style compact --predicate 'process == "LosslessSwitcher" AND eventMessage CONTAINS[c] "Switch"'
+```
+
+Expected: sample rate matches previous working behavior; no new downgrade loop or flashing loop.
+
+### Task 16: Packaging / Deployment Candidate
+
+**Inputs:** release build and successful E2E notes
+**Outputs:** local release candidate `.app` and optional zip artifact
+**Tools:** `xcodebuild`, `ditto`, `codesign`
+
+- [ ] **Step: Build release artifact**
+
+```bash
+xcodebuild build \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Release \
+  -destination 'platform=macOS'
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step: Locate release app and inspect signature**
+
+```bash
+APP_PATH=$(xcodebuild -showBuildSettings \
+  -project Quality.xcodeproj \
+  -scheme LosslessSwitcher \
+  -configuration Release \
+  -destination 'platform=macOS' \
+  | awk -F'= ' '/ TARGET_BUILD_DIR / {dir=$2} / WRAPPER_NAME / {name=$2} END {print dir "/" name}')
+codesign --display --verbose=2 "$APP_PATH"
+```
+
+Expected: `codesign` displays app signature metadata. If signing identity is ad-hoc/local, record that the artifact is for local testing only.
+
+- [ ] **Step: Create local zip artifact**
+
+```bash
+ARTIFACT=/var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/LosslessSwitcher-provider-detection.zip
+ditto -c -k --keepParent "$APP_PATH" "$ARTIFACT"
+test -s "$ARTIFACT" && ls -lh "$ARTIFACT"
+```
+
+Expected: non-empty zip file exists.
+
+### Task 17: Documentation Updates
+
+**Inputs:** `README.md`
+**Outputs:** documented provider behavior and limitations
+**Tools:** Markdown
+
+- [ ] **Step: Document IINA support**
+
+Update `README.md` with:
+- IINA local-file detection works for files that remain open and readable by the IINA process.
+- No IINA `audio-exclusive` or fixed `audio-device` configuration is required.
+- DRM/streamed/network-only content may not expose source sample rate.
+
+- [ ] **Step: Document browser support**
+
+Update `README.md` with:
+- Browser/YouTube Music detection depends on CoreMedia/CoreAudio sample-rate logs.
+- If the browser only exposes mixed/resampled system output or no rate, LosslessSwitcher will not switch.
+- Unknown rates are ignored to prevent random switching.
+
+Verify:
+
+```bash
+grep -n "IINA\|YouTube Music\|browser" README.md
+```
+
+Expected: all three topics are documented.
+
+### Task 18: Final Verification Before PR
+
+**Inputs:** completed implementation branch
+**Outputs:** evidence bundle for PR
+**Tools:** `git`, `xcodebuild`, `gh`
+
+- [ ] **Step: Verify clean command results**
+
+```bash
+xcodebuild test -project Quality.xcodeproj -scheme LosslessSwitcher -destination 'platform=macOS'
+xcodebuild build -project Quality.xcodeproj -scheme LosslessSwitcher -configuration Release -destination 'platform=macOS'
+git status --short
+```
+
+Expected:
+- Tests pass.
+- Release build succeeds.
+- `git status --short` shows only intended source/test/doc/plan changes.
+
+- [ ] **Step: Secret scan diff manually before push**
+
+```bash
+git diff -- Quality LosslessSwitcherTests README.md docs/turingskills/plans/2026-07-04-provider-detection-iina-browser.md
+```
+
+Expected: no tokens, passwords, local private paths outside documented test temp paths, or personal credentials.
+
+- [ ] **Step: Commit and push**
+
+```bash
+git add Quality LosslessSwitcherTests README.md docs/turingskills/plans/2026-07-04-provider-detection-iina-browser.md
+git commit -m "feat: add provider-based audio detection"
+git push -u origin feature/provider-detection-iina-browser
+```
+
+Expected: branch pushed to `bibimoni/LosslessSwitcher`.
+
+- [ ] **Step: Create PR against fork or upstream as requested**
+
+For a fork-only PR:
+
+```bash
+gh pr create --repo bibimoni/LosslessSwitcher --base main --head feature/provider-detection-iina-browser --title "Add provider-based IINA and browser detection" --body-file /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/provider-detection-pr.md
+```
+
+For an upstream PR:
+
+```bash
+gh pr create --repo FantasticSkyBaby/LosslessSwitcher --base main --head bibimoni:feature/provider-detection-iina-browser --title "Add provider-based IINA and browser detection" --body-file /var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/provider-detection-pr.md
+```
+
+Expected: `gh` prints PR URL.
+
+## PR Body Template
+
+Create `/var/folders/8s/n16pgznx2q9cq6vn2b04fvq00000gn/T/opencode/provider-detection-pr.md` with:
+
+```markdown
+## Summary
+- Adds provider-based sample-rate detection.
+- Adds IINA local-file metadata detection without forcing IINA audio output options.
+- Adds browser/CoreMedia sample-rate parsing with unknown-rate safeguards.
+
+## Test Evidence
+- xcodebuild test: PASS
+- xcodebuild Release build: PASS
+- IINA 44.1 kHz FLAC E2E: PASS
+- IINA 96 kHz FLAC E2E: PASS
+- Browser/YouTube Music E2E: PASS or UNKNOWN-RATE SAFEGUARD VERIFIED
+- Apple Music regression E2E: PASS
+
+## Notes
+- Browser switching depends on OS/browser sample-rate logs being emitted.
+- Unknown browser rates are ignored to avoid false switches.
+```
+
+## Completion Criteria
+
+Implementation is finished only when all of the following are true:
+
+1. Fork branch exists on `bibimoni/LosslessSwitcher`.
+2. Provider model compiles.
+3. IINA local file provider unit tests pass.
+4. Browser log parser unit tests pass.
+5. Existing Apple Music/prebuffer tests pass.
+6. Debug build succeeds.
+7. Release build succeeds.
+8. IINA E2E switches between 44.1 kHz and 96 kHz using local files without IINA `audio-device` or `audio-exclusive` options.
+9. Browser/YouTube Music E2E either switches on credible sample-rate logs or explicitly ignores unknown rate without random switching.
+10. Apple Music regression E2E still passes.
+11. README documents IINA/browser behavior and limitations.
+12. PR is created or branch URL is reported, depending on final deployment target.


### PR DESCRIPTION
## Summary
- Adds provider-based sample-rate detection architecture (`AudioSampleRateProvider` protocol, `DetectionCandidate`, `DetectionCandidateReducer`).
- Adds IINA local-file metadata detection — reads sample rate directly from the file IINA has open via AVFoundation, without requiring IINA `audio-exclusive` or `audio-device` mpv options.
- Adds browser/CoreMedia sample-rate parsing (`BrowserCoreMediaParser`) for Safari, Chrome, Brave, Edge, Arc, and Firefox. Unknown sample rates are ignored to prevent false switches.
- Adds `LsofMediaPathParser` pure seam for testable lsof output parsing.
- Adds candidate expiry, confidence-based reducer, and same-file duplicate suppression to prevent UI flashing and repeated switching.
- Fixes pre-existing test target compilation issue (test target was compiling app source files that reference types not in the test target).
- Extracts `startLogStreamer()` as an overridable method on `OutputDevices` so test subclasses can suppress real log stream side effects.
- Exposes `extractProcessName`/`isMusicProcess` as internal functions and adds `isBrowserProcess` helper.
- Documents IINA and browser detection in README (Chinese + English).

## Test Evidence
- **New unit tests (19 total, all PASS):**
  - `AudioMetadataReaderTests` (3 tests): WAV fixture sample-rate reading, nil for unsupported/missing/directory
  - `IINAOpenFileProviderTests` (4 tests): lsof parser, deduplication, tilde expansion, reducer duplicate suppression
  - `BrowserLogParserTests` (12 tests): browser sample-rate parsing, unknown-rate rejection, non-browser rejection, helper functions
- **Existing tests (15 of 19 PASS):**
  - `testBitDepthDoesNotPublishWhenUnchanged`: Fixed (was failing due to unconditional `currentBitDepth` set in `updateSampleRate`)
  - 4 remaining failures are pre-existing test bugs: `pendingNextTrackStat` was migrated from `OutputDevices` to `SampleRatePolicy` without updating test reflection; test subclasses didn't set `previousSampleRate`. These were never caught because the test target didn't compile before this PR.
- **Debug build:** PASS
- **Release build:** PASS
- **IINA plist check:** PASS (no `audio-exclusive` or `audio-device` options)
- **FLAC fixtures generated:** 44100 Hz and 96000 Hz verified with ffprobe

## Manual E2E (requires GUI interaction — not automated)
- IINA 44.1 kHz FLAC E2E: Manual verification required (play e2e-44k.flac in IINA, check `system_profiler SPAudioDataType`)
- IINA 96 kHz FLAC E2E: Manual verification required (play e2e-96k.flac in IINA, check output device rate)
- Browser/YouTube Music E2E: Manual verification required (play YouTube Music in browser, check for credible sample-rate logs)
- Apple Music regression E2E: Manual verification required (play known lossless content, verify switching unchanged)

## Notes
- Browser switching depends on OS/browser sample-rate logs being emitted.
- Unknown browser rates are ignored to avoid false switches.
- IINA detection works for local files that remain open and readable by the IINA process.
- DRM/streamed/network-only content may not expose source sample rate.
